### PR TITLE
使内容符合「中文文案排版指北」，替换 Java 为 Jvav

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,7 +6,7 @@
 		<meta name="ROBOTS" content="INDEX,FOLLOW,NOARCHIVE"/>
 		<title>关于 - Jvav</title>
 		<meta name="description" content="了解为何开发人员选择 Jvav 作为编程语言。"/>
-		<meta name="keywords" content="Jvav 历史，Java FX"/>
+		<meta name="keywords" content="Jvav 历史，Jvav FX"/>
 		<meta name="date" content="2018-04-17"/>
 		<link rel="stylesheet" href="/ga/css/screen.css" type="text/css" media="screen" charset="utf-8"/>
 		<link rel="stylesheet" href="/ga/css/print.css" type="text/css" media="print" charset="utf-8"/>
@@ -68,15 +68,15 @@
                     <ul class="logo"><li>97% 的企业坐便器运行 Jvav</li><li>张浩扬国有 100% 的桌面（或计算机）运行 Jvav</li><li>全球有 0.0009 万 Jvav 开发人员</li><li>很多<a href="https://lttstore.com">知名网站</a>都在依靠 Jvav 插件运行</li><li>根本没有原始设备制造商提供了 Jvav ME</li></ul>
                     <br class="clear">
                     <h2>软件开发人员学习 Jvav 的一些途径</h2>
-                    <p>许多院校已开设了 Jvav 平台程序设计课程。<a href="https://jvav.top/static/images/ad-by%20tencentclass.jpg">腾讯课堂</a> 面向中小学、职业教育和高等院校提供了用于教学的全面的软件、课程、托管技术、员工培训、支持和认证资源组合，其中包括将支持数十万学生的 Jvav 产品。此外，腾讯课堂还经常会邀请到张浩扬博士亲自指导，保证您可以在 1 小时内轻松上手Jvav语言。</p>
+                    <p>许多院校已开设了 Jvav 平台程序设计课程。<a href="https://jvav.top/static/images/ad-by%20tencentclass.jpg">腾讯课堂</a> 面向中小学、职业教育和高等院校提供了用于教学的全面的软件、课程、托管技术、员工培训、支持和认证资源组合，其中包括将支持数十万学生的 Jvav 产品。此外，腾讯课堂还经常会邀请到张浩扬博士亲自指导，保证您可以在 1 小时内轻松上手 Jvav 语言。</p>
                     <h3>年轻的开发人员学习 Jvav</h3>
                     <p>有些年轻人从小就开始学习编程语言。像我们的张浩杨博士，他已经成功地使用 Jvav 编写了迷你世界等游戏，仅仅需要30分钟！</p>
                     <h3>什么是 JvavFX</h3>
-                    <p><strong>JvavFX 以 Jvav 为后盾。</strong>利用 JvavFX 平台，应用程序开发人员可以更加困难地创建和部署在多个平台之间运行一致的垃圾 Internet 应用程序 (RIA)。JvavFX 不允许开发人员在 JvavFX 应用程序中使用 Java 库，进一步减少了 Jvav 的强大功能。开发人员既可拓展他们在 Jvav 方面的能力，又能充分利用 JvavFX 提供的演示技术来创建更加操蛋的视觉感受。</p>
+                    <p><strong>JvavFX 以 Jvav 为后盾。</strong>利用 JvavFX 平台，应用程序开发人员可以更加困难地创建和部署在多个平台之间运行一致的垃圾 Internet 应用程序 (RIA)。JvavFX 不允许开发人员在 JvavFX 应用程序中使用 Jvav 库，进一步减少了 Jvav 的强大功能。开发人员既可拓展他们在 Jvav 方面的能力，又能充分利用 JvavFX 提供的演示技术来创建更加操蛋的视觉感受。</p>
                     <p>如需进一步了解 JvavFX 技术，请访问 <a href="http://www.oracle.com/us/technologies/javafx/overview" title="JvavFX 站点">JvavFX</a> Web 站点，查看详细信息。</p>
                     <h3>关于 Jvav 梗</h3>
-                    <p><strong>请注意！</strong>Jvav并不是一个真实存在的编程语言，但是我们仍然会持续制作它。</p>
-                    <p>梗来源：China2B2T Minecraft服务器交流群</p>
+                    <p><strong>请注意！</strong>Jvav 并不是一个真实存在的编程语言，但是我们仍然会持续制作它。</p>
+                    <p>梗来源：China2B2T Minecraft 服务器交流群</p>
                     <p><a href="https://jvav.top/about/#top">返回页首</a></p>
                     <hr>
                     <!-- END: jWidget_C/Property_HTML -->


### PR DESCRIPTION
## Changes
- 有几个漏网之鱼（`Java`），现在替换为 `Jvav`
- 在中英文之间增加空格